### PR TITLE
Java class compile version 8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,11 @@ lazy val core = (project in file("core"))
 
     javaOptions += "-Xmx1024m",
 
+    javacOptions ++= Seq(
+      "-source", "1.8",
+      "-target", "1.8"
+    ),
+
     // Configurations to speed up tests and reduce memory footprint
     Test / javaOptions ++= Seq(
       "-Dspark.ui.enabled=false",


### PR DESCRIPTION
Solves java 11 class file issue by changing the output java class file version to 8 - I will also upload the new jar to the main project for parity.